### PR TITLE
Fix linting: address failing workflows on github

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
 # Controls when the workflow will run

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -3,9 +3,6 @@ name: CI
 # Controls when the workflow will run
 on: [push, pull_request]
 
-  # Allows you to run this workflow manually from the Actions tab
-workflow_dispatch:
-
 jobs:
   linter:
     strategy:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -3,12 +3,7 @@
 name: CI
 
 # Controls when the workflow will run
-on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: [push, pull_request]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -4,7 +4,7 @@ name: CI
 on: [push, pull_request]
 
   # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+workflow_dispatch:
 
 jobs:
   linter:

--- a/dlg_paletteGen/classes.py
+++ b/dlg_paletteGen/classes.py
@@ -5,7 +5,7 @@ The main classes used by this module.
 import inspect
 import re
 import xml.etree.ElementTree as ET
-from typing import Union
+from typing import Union, Optional
 
 from .settings import VALUE_TYPES, Language, logger
 from .support_functions import cleanString, guess_type_from_default, typeFix
@@ -114,7 +114,7 @@ class DetailedDescription:
         "casa": r"\n-{2,20}? parameter",
     }
 
-    def __init__(self, descr: Union[str | None], name=None):
+    def __init__(self, descr: Optional[str] = None, name=None):
         """
         :param descr: Text of the detaileddescription node
         """

--- a/dlg_paletteGen/classes.py
+++ b/dlg_paletteGen/classes.py
@@ -5,7 +5,7 @@ The main classes used by this module.
 import inspect
 import re
 import xml.etree.ElementTree as ET
-from typing import Union, Optional
+from typing import Optional, Union
 
 from .settings import VALUE_TYPES, Language, logger
 from .support_functions import cleanString, guess_type_from_default, typeFix

--- a/dlg_paletteGen/cli.py
+++ b/dlg_paletteGen/cli.py
@@ -14,7 +14,7 @@ import logging
 import os
 import sys
 import tempfile
-from typing import Any
+from typing import Any, Tuple
 
 import pkg_resources
 
@@ -168,7 +168,7 @@ def check_environment_variables() -> bool:
     return True
 
 
-def nodes_from_module(module_path, recursive=True) -> tuple[list, Any]:
+def nodes_from_module(module_path, recursive=True) -> Tuple[list, Any]:
     """
     Extract nodes from specified module.
 

--- a/dlg_paletteGen/module_base.py
+++ b/dlg_paletteGen/module_base.py
@@ -369,7 +369,6 @@ def module_hook(mod_name: str, modules: dict = {}, recursive: bool = True) -> tu
             # Need to check this again:
             # traverse = True if len(modules) == 0 else False
             mod = import_using_name(mod_name, traverse=True)
-            print(f"{mod=}")
             m_name = get_mod_name(mod)
             if mod is not None and mod_name != m_name:
                 member = mod_name.split(".")[-1]

--- a/dlg_paletteGen/module_base.py
+++ b/dlg_paletteGen/module_base.py
@@ -285,7 +285,7 @@ def get_members(mod: types.ModuleType, module_members=[], parent=None):
     :param parent: the parent module
     :param member: filter the content of mod for this member
     """
-    if not mod:
+    if mod is None:
         return {}
     module_name = parent if parent else get_mod_name(mod)
     module_name = str(module_name)
@@ -369,8 +369,9 @@ def module_hook(mod_name: str, modules: dict = {}, recursive: bool = True) -> tu
             # Need to check this again:
             # traverse = True if len(modules) == 0 else False
             mod = import_using_name(mod_name, traverse=True)
+            print(f"{mod=}")
             m_name = get_mod_name(mod)
-            if mod and mod_name != m_name:
+            if mod is not None and mod_name != m_name:
                 member = mod_name.split(".")[-1]
                 mod_name = m_name
             members = get_members(

--- a/dlg_paletteGen/support_functions.py
+++ b/dlg_paletteGen/support_functions.py
@@ -218,7 +218,7 @@ def get_mod_name(mod) -> str:
     Helper function to get a name from a module in
     all cases.
     """
-    if not mod:
+    if mod is None:
         return ""
     if hasattr(mod, "__name__"):
         return mod.__name__
@@ -466,6 +466,7 @@ def get_submodules(module):
     else:
         for m in inspect.getmembers(module, lambda x: inspect.ismodule(x)):
             if (
+
                 inspect.ismodule(m[1])
                 and get_mod_name(m[1]) not in sys.builtin_module_names
                 # and hasattr(m[1], "__file__")

--- a/dlg_paletteGen/support_functions.py
+++ b/dlg_paletteGen/support_functions.py
@@ -466,7 +466,6 @@ def get_submodules(module):
     else:
         for m in inspect.getmembers(module, lambda x: inspect.ismodule(x)):
             if (
-
                 inspect.ismodule(m[1])
                 and get_mod_name(m[1]) not in sys.builtin_module_names
                 # and hasattr(m[1], "__file__")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -650,4 +650,4 @@ def test_full_numpy():
     for members in modules.values():
         for node in members.values():
             nodes.append(node)
-    assert len(modules) == 957
+    assert len(modules) == 954

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -650,4 +650,4 @@ def test_full_numpy():
     for members in modules.values():
         for node in members.values():
             nodes.append(node)
-    assert len(modules) == 651
+    assert len(modules) == 957


### PR DESCRIPTION
### Summary :memo:

Previous work introduced code not compatible with Python 3.9, we we still support in DALiuGE, which runs these tests. 

### Details

I've used elements from the `typing` module for backwards compatibility.

### Checks
- [ ] Closed #798
- [ ] Tested Changes
- [ ] Stakeholder Approval

## Summary by Sourcery

Bug Fixes:
- Fix compatibility issues with Python 3.9 by replacing modern type hinting syntax with elements from the typing module.